### PR TITLE
feature: 이미지 리사이징 & 드래그 시 이미지 이동영역 제한

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# 빌드 스테이지
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# 런타임 스테이지
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/public ./public
+
+# 포트 설정
+EXPOSE 3000
+
+# Next.js 시작 명령어
+CMD ["npm", "start"]

--- a/app/(root-upload)/(components)/uploadPanel.module.scss
+++ b/app/(root-upload)/(components)/uploadPanel.module.scss
@@ -28,16 +28,17 @@
         border-radius: 8px;
         border: 1px solid #c9c9c9;
         box-shadow: 0 0 1px 0px white inset, 0 0 1px 0px white;
+
         flex: 0 0 auto;
         overflow: hidden;
-        width: 200px;
+        width: 250px;
+
+        display: flex;
+        align-items: center;
+        justify-content: center;
 
         img {
-          width: 200px;
-          // height: 250px;
-          transform: scale(0.4);
-          // object-fit: none;
-          // object-position: 50% 50%;
+          max-height: 300px;
         }
       }
       li + li {

--- a/app/edit/(components)/Resizer.tsx
+++ b/app/edit/(components)/Resizer.tsx
@@ -61,12 +61,6 @@ export default function Resizer({ src, selectedIdx }: Props) {
   };
 
   const update = () => {
-    console.log(offset, zoomFactor, -offset.x / zoomFactor);
-    console.log(
-      imgRef.current?.width,
-      imgRef.current?.height,
-      document.body.clientWidth
-    );
     setTimeout(() => {
       if (imgRef.current) {
         imgRef.current.style.transform = `scale(${zoomFactor}) translate(${

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.8"
+services:
+  nextjs:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=production
+    container_name: nextjs-container


### PR DESCRIPTION
## [변경점]
- 이미지 리사이징 & 드래그 시 이미지 이동영역 제한
  - 가로 / 세로 사이즈가 이미지 viewer(resizer) 사이즈보다 작을때는 centerize
  - 가로 / 세로 사이즈가 이미지 viewer(resizer) 사이즈보다 클때는 left, top, right, bottom limit 을 벗어나지 않게끔 조정
  - 리사이징으로 인한 이미지 이동시에도 동일 적용

> 인스타그램 게시글 업로드시 이미지 편집 화면의 동작 참고함